### PR TITLE
Add travis jobs on ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 sudo: false
 
 language: c
+
+arch:
+ - amd64
+ - ppc64le
+ 
 compiler:
   - clang
   - gcc


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/manish364824/liboping/builds/199583210

Please have a look.

Regards,
Manish